### PR TITLE
Fix: Add subject-name in the display of assignments. (Issue #18)

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,10 @@ def main():
             print("No pending assignments!")
         else:
             for assignment in assignments:
-                print(f"- {assignment['title']} (Due: {assignment['deadline']})")
+                if assignment['subject'] is not None:
+                    print(f"- {assignment['title']} [Subject: {assignment['subject']}] (Due: {assignment['deadline']})")
+                else:
+                    print(f"- {assignment['title']} (Due: {assignment['deadline']})")
 
     elif args.command == 'complete':
         if manager.mark_completed(args.value):


### PR DESCRIPTION
## Fix: Add subject-name to assignment display
Closes #18

## What?
Updated the `list` command to include the subject name when displaying assignments.

## Why?
Previously, `python main.py list` only showed titles and deadlines. Adding the subject name provides better context for users while maintaining a clean interface for assignments without a linked subject.

## How?
Modified the display logic to check for the existence of a `subject-name`. 
- If present: Displays `Title [Subject] (Deadline)`.
- If absent: Displays only `Title (Deadline)` (default behavior).

## Testing
1. Run `python main.py list` with assignments that have subjects.
2. Run `python main.py list` with assignments that do NOT have subjects.
3. Verify the subject name appears only when intended.